### PR TITLE
Remove JSON encoding and decoding functionality

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,6 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/json": "1.1.3 <= v < 2.0.0",
         "elm/parser": "1.1.0 <= v < 2.0.0"
     },
     "test-dependencies": {

--- a/src/Semver.elm
+++ b/src/Semver.elm
@@ -24,7 +24,7 @@ For the definition of semantic versioning with Semver 2.0.0, see
 
 # Handling Version Strings
 
-@docs print, parse, decode, encode
+@docs print, parse
 
 -}
 

--- a/src/Semver.elm
+++ b/src/Semver.elm
@@ -1,7 +1,7 @@
 module Semver exposing
     ( Version, version, isValid
     , compare, lessThan, greaterThan
-    , print, parse, decode, encode
+    , print, parse
     )
 
 {-| Provides basic functionality for handling semantic version numbers. Follows
@@ -29,8 +29,6 @@ For the definition of semantic versioning with Semver 2.0.0, see
 -}
 
 import Char
-import Json.Decode as JD exposing (Decoder)
-import Json.Encode as JE
 import Parser exposing ((|.), (|=), Parser)
 
 
@@ -191,25 +189,6 @@ parse : String -> Maybe Version
 parse versionString =
     Parser.run parser versionString
         |> Result.toMaybe
-
-
-{-| Decode a version from a JSON value.
--}
-decode : Decoder Version
-decode =
-    let
-        maybeToDecoder =
-            Maybe.map JD.succeed
-                >> Maybe.withDefault (JD.fail "Invalid version string.")
-    in
-    JD.string |> JD.andThen (parse >> maybeToDecoder)
-
-
-{-| Encode a version as JSON.
--}
-encode : Version -> JE.Value
-encode =
-    print >> JE.string
 
 
 parser : Parser Version


### PR DESCRIPTION
This is just a very minimal layer on top of the printing/parsing functions. Now that the JSON support has been removed from core, culling those convenience functions allows us to keep dependencies minimal.